### PR TITLE
refactor: update README.md with correct links and prefix settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ copilot-practice2
 
 ## 作成方法
 - `git clone`でリポジトリをダウンロード
-- ルートディレクトリにある`.env.sample`ファイルをコピーして、`.env`ファイルを作成
+- ルートディレクトリにある`.env.sample`ファイルをコピーして、`.env`ファイルを作成<br>
+   設定は変更せず、passwordはブランクのままにしてください。
 - `$ docker compose build --no-cache`でDockerイメージをビルド
 - パッケージ管理はpoetryを使用<br>
 　backendとfrontendのそれぞれの定義ファイルからインストール<br>
@@ -133,8 +134,9 @@ https://github.com/github/gitignore/blob/main/Python.gitignore
 - GitHub ActionsのCI実行
    - 実行ファイル
       `.github/workflows/pytest.yml`<br>
-      😢表示されるパスがbackendディレクトリ、frontendディレクトリからになってしまうため、リンクが飛ばない。
-      <br>（ルートディレクトリからにできない😭）
+      `backend`, `frontend`で処理を分けています。
+      `coverage-path-prefix`を設定することで、リンクのパスに飛ぶようになりました。
+
 
    - GitHub Actionsの処理について
       参考ページ


### PR DESCRIPTION
… coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
	- `.env`ファイルの作成方法に関する指示を追加しました。設定を変更せずにパスワードを空白のままにする方法です。
	- GitHub Actions CIの実行詳細を更新し、`backend`と`frontend`の処理を分け、正しいリンクパスのための新しい`coverage-path-prefix`設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->